### PR TITLE
変数ブロックでtypeが宣言されていなかった箇所を修正

### DIFF
--- a/environments/immutable/variable.tf
+++ b/environments/immutable/variable.tf
@@ -1,4 +1,5 @@
 variable "common" {
+    type = "map"
     default = {
         default.region     = "us-west-2"
         default.project    = "oreno-project"

--- a/environments/not_immutable/variable.tf
+++ b/environments/not_immutable/variable.tf
@@ -1,4 +1,5 @@
 variable "common" {
+    type = "map"
     default = {
         default.region     = "us-west-2"
         default.project    = "oreno-project"


### PR DESCRIPTION
はじめまして！

こちらのプロジェクトですが [Terraform Best Practices in 2017](https://qiita.com/shogomuranushi/items/e2f3ff3cfdcacdd17f99) も含め、大変参考になりました。

表題の通り、以下のファイル内で宣言されている変数に type の宣言がされていなかったので修正を行いました。

- `environments/immutable/variable.tf`
- `environments/not_immutable/variable.tf`

ご確認のよろしくお願いします！